### PR TITLE
Removed left_click lag

### DIFF
--- a/TreeDataView.py
+++ b/TreeDataView.py
@@ -81,7 +81,7 @@ class TreeDataView(tk.Frame):
             self.tree.column(col, width=font.Font().measure(col.title()))
 
         if left_click:
-            self.tree.bind('<Button-1>', left_click)
+            self.tree.bind('<<TreeviewSelect>>', left_click)
         else:
             pass
 


### PR DESCRIPTION
The <Button-1> event triggers before the window notices that the selection has changed, so selection() returns the thing that was selected before the click which creates sort of a lag.